### PR TITLE
feat: add boss augments and stacking system

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -63,6 +63,13 @@ const messages = {
         bounce: '↩️弹射',
         split: '🔀分裂'
       },
+      chooseAugment: '选择增强',
+      augment: {
+        atk: '攻击力+20%',
+        aspd: '攻速+10%',
+        speed: '移速+10%',
+        hp: '最大生命+20'
+      },
       youDied: '你阵亡了',
       pressStart: '按 Start/Esc 切换暂停'
     }
@@ -128,6 +135,13 @@ const messages = {
         pierce: '🎯Pierce',
         bounce: '↩️Bounce',
         split: '🔀Split'
+      },
+      chooseAugment: 'Choose Augment',
+      augment: {
+        atk: 'Attack +20%',
+        aspd: 'Attack Speed +10%',
+        speed: 'Move Speed +10%',
+        hp: 'Max HP +20'
       },
       youDied: 'You Died',
       pressStart: 'Press Start/Esc to toggle pause'


### PR DESCRIPTION
## Summary
- Introduce permanent Augments that drop from bosses and stack per selection
- Add multi-stage boss progression and augment pick UI
- Localize augment labels and selection prompt in Chinese and English

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a9434f63083278e0e5682193787a7