### PR TITLE
feat: add three.js 2.5D game view

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 🎮 游戏简介 / Game Description
 - **中文**：  
-  一款刺激的 2D 动作射击游戏，玩家将操控角色与源源不断的怪兽进行战斗，利用武器、技能和策略击败敌人，保卫自己的阵地。支持手柄与触控双摇杆操作，体验畅快的打击感与紧张刺激的战斗节奏。
+  一款使用 three.js 实现的 2.5D 动作射击游戏，玩家将操控角色与源源不断的怪兽进行战斗，利用武器、技能和策略击败敌人，保卫自己的阵地。支持手柄与触控双摇杆操作，体验畅快的打击感与紧张刺激的战斗节奏。
 
 - **English**:  
-  A thrilling 2D action shooter where players control a hero to battle endless waves of monsters. Use weapons, skills, and strategies to defeat enemies and protect your base. Supports both gamepad and dual virtual joystick controls for an intense and satisfying combat experience.
+  A thrilling 2.5D action shooter rendered with three.js where players control a hero to battle endless waves of monsters. Use weapons, skills, and strategies to defeat enemies and protect your base. Supports both gamepad and dual virtual joystick controls for an intense and satisfying combat experience.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "vue": "^3.5.18",
     "vue-router": "^4.4.5",
-    "vue-i18n": "^9.5.0"
+    "vue-i18n": "^9.5.0",
+    "three": "^0.159.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,10 +1,10 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
-import GameView from '../views/GameView.vue'
+import Game3DView from '../views/Game3DView.vue'
 
 const routes = [
   { path: '/', name: 'home', component: HomeView },
-  { path: '/game', name: 'game', component: GameView }
+  { path: '/game', name: 'game', component: Game3DView }
 ]
 
 const router = createRouter({

--- a/src/views/Game3DView.vue
+++ b/src/views/Game3DView.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="three-wrap" ref="mountEl"></div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import * as THREE from 'three'
+
+const mountEl = ref(null)
+let scene, camera, renderer, player, animationId
+const keys = { ArrowUp:false, ArrowDown:false, ArrowLeft:false, ArrowRight:false }
+const speed = 0.1
+
+function onKeyDown(e){ if(e.key in keys) keys[e.key] = true }
+function onKeyUp(e){ if(e.key in keys) keys[e.key] = false }
+
+function animate(){
+  animationId = requestAnimationFrame(animate)
+  if(keys.ArrowUp) player.position.z -= speed
+  if(keys.ArrowDown) player.position.z += speed
+  if(keys.ArrowLeft) player.position.x -= speed
+  if(keys.ArrowRight) player.position.x += speed
+  renderer.render(scene, camera)
+}
+
+onMounted(()=>{
+  scene = new THREE.Scene()
+  const width = mountEl.value.clientWidth
+  const height = mountEl.value.clientHeight
+  camera = new THREE.PerspectiveCamera(60, width/height, 0.1, 100)
+  camera.position.set(0,5,8)
+  camera.lookAt(0,0,0)
+
+  renderer = new THREE.WebGLRenderer({ antialias: true })
+  renderer.setSize(width, height)
+  mountEl.value.appendChild(renderer.domElement)
+
+  const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1)
+  scene.add(light)
+
+  const ground = new THREE.Mesh(
+    new THREE.PlaneGeometry(20,20),
+    new THREE.MeshStandardMaterial({ color:0x222222 })
+  )
+  ground.rotation.x = -Math.PI/2
+  scene.add(ground)
+
+  player = new THREE.Mesh(
+    new THREE.BoxGeometry(1,1,1),
+    new THREE.MeshStandardMaterial({ color:0x00ff00 })
+  )
+  player.position.y = 0.5
+  scene.add(player)
+
+  window.addEventListener('keydown', onKeyDown)
+  window.addEventListener('keyup', onKeyUp)
+  animate()
+})
+
+onBeforeUnmount(()=>{
+  cancelAnimationFrame(animationId)
+  window.removeEventListener('keydown', onKeyDown)
+  window.removeEventListener('keyup', onKeyUp)
+  renderer && renderer.dispose()
+})
+</script>
+
+<style scoped>
+.three-wrap {
+  width: 100vw;
+  height: 100dvh;
+  overflow: hidden;
+}
+</style>


### PR DESCRIPTION
## Summary
- integrate three.js to render a basic 2.5D scene
- route game path to new 3D view
- document 2.5D three.js usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "three" because package isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_689aa2568f6c8327927108f5e4c3751e