### PR TITLE
feat: add svg towers and loader

### DIFF
--- a/src/assets/svg/towers/tower_arrow_lvl1.svg
+++ b/src/assets/svg/towers/tower_arrow_lvl1.svg
@@ -1,18 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <style>
-    :root{ --c-main:#3b82f6; --c-accent:#60a5fa; --c-dark:#0f172a; --c-lite:#bfdbfe; }
-  </style>
-  <!-- base -->
-  <use href="tower_base_pad.svg#pad" />
-  <!-- body -->
-  <g transform="translate(0,-6)">
-    <rect x="26" y="22" width="12" height="18" rx="3" fill="var(--c-main)" stroke="var(--c-dark)" stroke-width="2"/>
-    <rect x="28" y="24" width="8" height="8" rx="2" fill="var(--c-accent)"/>
-    <!-- turret -->
-    <g transform="translate(32,26)">
-      <circle cx="0" cy="0" r="7" fill="var(--c-accent)" stroke="var(--c-dark)" stroke-width="2"/>
-      <rect x="6" y="-2" width="16" height="4" rx="2" fill="var(--c-lite)" stroke="var(--c-dark)" stroke-width="2"/>
-      <polygon points="22,0 18,-3 18,3" fill="var(--c-dark)"/>
-    </g>
-  </g>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+<style>
+:root{--main-color:#3b82f6;}
+</style>
+<rect x="28" y="20" width="8" height="24" fill="var(--main-color)"/>
+<polygon points="32,8 24,20 40,20" fill="var(--main-color)"/>
 </svg>

--- a/src/assets/svg/towers/tower_base_pad.svg
+++ b/src/assets/svg/towers/tower_base_pad.svg
@@ -1,17 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <style>
-    :root{ --c-dark:#1e293b; --c-lite:#94a3b8; --c-main:#3b82f6; }
-  </style>
-  <defs>
-    <radialGradient id="g" cx="50%" cy="60%" r="60%">
-      <stop offset="0" stop-color="#000" stop-opacity=".35"/>
-      <stop offset="1" stop-color="#000" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-  <!-- ground shadow -->
-  <ellipse cx="32" cy="46" rx="18" ry="8" fill="url(#g)"/>
-  <!-- pad -->
-  <path d="M16 44h32l4-6-4-6H16l-4 6 4 6Z" fill="var(--c-dark)"/>
-  <path d="M18 42h28l3-4-3-4H18l-3 4 3 4Z" fill="#475569"/>
-  <path d="M20 40h24l2-2-2-2H20l-2 2 2 2Z" fill="var(--c-lite)"/>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+<style>
+:root{--pad:#6b7280;}
+</style>
+<ellipse cx="32" cy="48" rx="20" ry="8" fill="#00000033"/>
+<circle cx="32" cy="40" r="20" fill="var(--pad)"/>
 </svg>

--- a/src/assets/svg/towers/tower_cannon_lvl1.svg
+++ b/src/assets/svg/towers/tower_cannon_lvl1.svg
@@ -1,19 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <style>
-    :root{ --c-main:#64748b; --c-accent:#94a3b8; --c-dark:#0f172a; --c-lite:#cbd5e1; }
-  </style>
-  <!-- base pad（简化直接画，不外链） -->
-  <ellipse cx="32" cy="48" rx="18" ry="8" fill="rgba(0,0,0,.28)"/>
-  <path d="M16 46h32l4-6-4-6H16l-4 6 4 6Z" fill="#1f2937"/>
-  <path d="M18 44h28l3-4-3-4H18l-3 4 3 4Z" fill="#334155"/>
-  <!-- body -->
-  <g transform="translate(0,-2)">
-    <rect x="24" y="22" width="16" height="16" rx="4" fill="var(--c-main)" stroke="var(--c-dark)" stroke-width="2"/>
-    <!-- rotating head -->
-    <g transform="translate(32,26)">
-      <circle r="7" fill="var(--c-accent)" stroke="var(--c-dark)" stroke-width="2"/>
-      <rect x="7" y="-3" width="18" height="6" rx="3" fill="var(--c-lite)" stroke="var(--c-dark)" stroke-width="2"/>
-      <circle cx="26" cy="0" r="3" fill="var(--c-dark)"/>
-    </g>
-  </g>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+<style>
+:root{--main-color:#3b82f6;}
+</style>
+<rect x="24" y="28" width="16" height="20" fill="var(--main-color)"/>
+<circle cx="32" cy="20" r="10" fill="var(--main-color)"/>
 </svg>

--- a/src/assets/svg/towers/tower_ice_lvl1.svg
+++ b/src/assets/svg/towers/tower_ice_lvl1.svg
@@ -1,9 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <style>
-    :root{ --c-main:#22d3ee; --c-accent:#67e8f9; --c-dark:#0e7490; --c-lite:#e0f2fe; }
-  </style>
-  <ellipse cx="32" cy="48" rx="18" ry="8" fill="rgba(0,0,0,.24)"/>
-  <path d="M20 44l12-20 12 20-12 4-12-4Z" fill="var(--c-main)" stroke="var(--c-dark)" stroke-width="2"/>
-  <path d="M32 24l6 10-6 2-6-2 6-10Z" fill="var(--c-accent)"/>
-  <circle cx="32" cy="30" r="4" fill="var(--c-lite)" opacity=".8"/>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+<style>
+:root{--main-color:#3b82f6;}
+</style>
+<polygon points="32,12 40,24 32,36 24,24" fill="var(--main-color)"/>
+<polygon points="32,36 40,48 32,60 24,48" fill="var(--main-color)"/>
 </svg>

--- a/src/assets/svg/towers/tower_ice_lvl2.svg
+++ b/src/assets/svg/towers/tower_ice_lvl2.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+<style>
+:root{--main-color:#3b82f6;}
+</style>
+<polygon points="32,8 40,20 32,32 24,20" fill="var(--main-color)"/>
+<polygon points="32,32 40,44 32,56 24,44" fill="var(--main-color)"/>
+<polygon points="32,20 44,32 32,44 20,32" fill="var(--main-color)"/>
+</svg>

--- a/src/assets/svg/towers/tower_ice_lvl3.svg
+++ b/src/assets/svg/towers/tower_ice_lvl3.svg
@@ -1,0 +1,9 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+<style>
+:root{--main-color:#3b82f6;}
+</style>
+<polygon points="32,6 42,20 32,34 22,20" fill="var(--main-color)"/>
+<polygon points="32,34 42,48 32,62 22,48" fill="var(--main-color)"/>
+<polygon points="32,20 50,32 32,44 14,32" fill="var(--main-color)"/>
+<polygon points="32,12 44,32 32,52 20,32" fill="var(--main-color)" opacity="0.6"/>
+</svg>

--- a/src/assets/svg/towers/tower_tesla_lvl1.svg
+++ b/src/assets/svg/towers/tower_tesla_lvl1.svg
@@ -1,14 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <style>
-    :root{ --c-main:#7c3aed; --c-accent:#a78bfa; --c-dark:#1e1b4b; --c-lite:#ddd6fe; }
-  </style>
-  <ellipse cx="32" cy="48" rx="18" ry="8" fill="rgba(0,0,0,.24)"/>
-  <rect x="26" y="28" width="12" height="14" rx="3" fill="var(--c-main)" stroke="var(--c-dark)" stroke-width="2"/>
-  <g transform="translate(32,24)">
-    <circle r="7" fill="var(--c-accent)" stroke="var(--c-dark)" stroke-width="2"/>
-    <path d="M-4 0 L-1 -3 L1 3 L4 0" fill="none" stroke="var(--c-lite)" stroke-width="2"/>
-  </g>
-  <!-- coils -->
-  <rect x="22" y="30" width="4" height="10" rx="2" fill="var(--c-accent)"/>
-  <rect x="38" y="30" width="4" height="10" rx="2" fill="var(--c-accent)"/>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+<style>
+:root{--main-color:#3b82f6;}
+</style>
+<circle cx="32" cy="32" r="12" stroke="var(--main-color)" stroke-width="4" fill="none"/>
+<rect x="30" y="12" width="4" height="12" fill="var(--main-color)"/>
+<rect x="30" y="40" width="4" height="12" fill="var(--main-color)"/>
 </svg>

--- a/src/core/engine/Game.ts
+++ b/src/core/engine/Game.ts
@@ -72,7 +72,7 @@ class Game {
 
     for (const t of towersData as TowerDef[]) this.towerDefs[t.id] = t
     this.projectiles = new ProjectileManager(this.statuses, this.enemies)
-    this.towers = new TowerManager(this.towerDefs, this.projectiles)
+    this.towers = new TowerManager(this.towerDefs, this.projectiles, this.renderer.towerLayer, level.tileSize)
 
     this.cols = Math.floor(level.width / level.tileSize)
     this.rows = Math.floor(level.height / level.tileSize)
@@ -101,11 +101,10 @@ class Game {
       const def = this.towerDefs[this.buildId]
       const cx = gx * level.tileSize + level.tileSize / 2
       const cy = gy * level.tileSize + level.tileSize / 2
-      if (this.canPlace(gx, gy, this.buildId) && this.economy.spend(def.cost)) {
-        this.towers.placeTower(def.id, cx, cy)
-        this.renderer.drawTowers(this.towers.towers)
-        callbacks.gold && callbacks.gold(this.economy.gold)
-      }
+        if (this.canPlace(gx, gy, this.buildId) && this.economy.spend(def.cost)) {
+          this.towers.placeTower(def.id, cx, cy)
+          callbacks.gold && callbacks.gold(this.economy.gold)
+        }
     })
     this.input.onCommand(cmd => {
       switch (cmd) {
@@ -143,7 +142,6 @@ class Game {
         const tower = this.towers.placeTower(t.id, cx, cy)
         if (tower) tower.level = t.level
       }
-      this.renderer.drawTowers(this.towers.towers)
       this.currentWave = this.waves.currentWave + 1
       callbacks.wave && callbacks.wave(this.currentWave)
     }
@@ -164,7 +162,6 @@ class Game {
         this.projectiles.update(dt)
         this.statuses.tick(dt)
         this.renderer.drawEnemies(this.enemies.enemies)
-        this.renderer.drawTowers(this.towers.towers)
         this.renderer.drawProjectiles(this.projectiles.projectiles)
         if (!this.waves.isWaveRunning()) this.running = false
         this.currentWave = this.waves.currentWave + 1

--- a/src/core/engine/Renderer.ts
+++ b/src/core/engine/Renderer.ts
@@ -13,7 +13,7 @@ export class Renderer {
 
   private gridG = new Graphics()
   public laneLayer = new Container()
-  private towerLayer = new Container()
+  public towerLayer = new Container()
   private enemyLayer = new Container()
   private projectileLayer = new Container()
   private overlayLayer = new Container()

--- a/src/core/engine/SvgAssets.ts
+++ b/src/core/engine/SvgAssets.ts
@@ -31,8 +31,12 @@ export const SvgAssets = {
 
 export const TowerBasePad = '/src/assets/svg/towers/tower_base_pad.svg'
 export const TowerSpriteMap = {
-  arrow: '/src/assets/svg/towers/tower_arrow_lvl1.svg',
-  cannon: '/src/assets/svg/towers/tower_cannon_lvl1.svg',
-  ice: '/src/assets/svg/towers/tower_ice_lvl1.svg',
-  tesla: '/src/assets/svg/towers/tower_tesla_lvl1.svg',
+  arrow: ['/src/assets/svg/towers/tower_arrow_lvl1.svg'],
+  cannon: ['/src/assets/svg/towers/tower_cannon_lvl1.svg'],
+  ice: [
+    '/src/assets/svg/towers/tower_ice_lvl1.svg',
+    '/src/assets/svg/towers/tower_ice_lvl2.svg',
+    '/src/assets/svg/towers/tower_ice_lvl3.svg'
+  ],
+  tesla: ['/src/assets/svg/towers/tower_tesla_lvl1.svg'],
 } as const

--- a/src/core/engine/SvgAssets.ts
+++ b/src/core/engine/SvgAssets.ts
@@ -1,0 +1,38 @@
+import { Texture } from 'pixi.js'
+
+const cache = new Map<string, Texture>()
+
+export const SvgAssets = {
+  async load(path: string): Promise<Texture> {
+    if (cache.has(path)) return cache.get(path)!
+    const tex = Texture.from(path)
+    await new Promise<void>(res => requestAnimationFrame(() => res()))
+    ;(tex.baseTexture as any).resource?.update?.()
+    cache.set(path, tex)
+    return tex
+  },
+  async preload(paths: string[]): Promise<void> {
+    await Promise.all(paths.map(p => this.load(p)))
+  },
+  texture(path: string): Texture {
+    const t = cache.get(path)
+    if (!t) throw new Error(`SVG not loaded: ${path}`)
+    return t
+  },
+  replaceColor(tex: Texture, cssVar: string, color: string) {
+    const res: any = tex.baseTexture.resource
+    if (res && typeof res.source === 'string') {
+      const re = new RegExp(`--${cssVar}:[^;]+`, 'i')
+      res.source = res.source.replace(re, `--${cssVar}:${color}`)
+      res.update()
+    }
+  }
+}
+
+export const TowerBasePad = '/src/assets/svg/towers/tower_base_pad.svg'
+export const TowerSpriteMap = {
+  arrow: '/src/assets/svg/towers/tower_arrow_lvl1.svg',
+  cannon: '/src/assets/svg/towers/tower_cannon_lvl1.svg',
+  ice: '/src/assets/svg/towers/tower_ice_lvl1.svg',
+  tesla: '/src/assets/svg/towers/tower_tesla_lvl1.svg',
+} as const

--- a/src/core/gameplay/Tower.ts
+++ b/src/core/gameplay/Tower.ts
@@ -1,5 +1,6 @@
 import type { DamageType } from './DamageSystem'
 import type { StatusEffect } from '../data/types'
+import type { Container, Sprite } from 'pixi.js'
 
 export interface TowerStats {
   range: number
@@ -26,4 +27,9 @@ export class Tower {
     this.uid = Math.random().toString(36).slice(2)
     if (!this.stats.targetPriority) this.stats.targetPriority = 'first'
   }
+
+  // display containers for rendering
+  node!: Container
+  head!: Container
+  headSprite!: Sprite
 }

--- a/src/core/gameplay/TowerManager.ts
+++ b/src/core/gameplay/TowerManager.ts
@@ -39,7 +39,9 @@ export class TowerManager {
     node.addChild(baseSp)
 
     const headWrap = new Container()
-    const headSp = new Sprite(SvgAssets.texture(TowerSpriteMap[towerId as keyof typeof TowerSpriteMap]))
+    const headSp = new Sprite(
+      SvgAssets.texture(TowerSpriteMap[towerId as keyof typeof TowerSpriteMap][0])
+    )
     headSp.anchor.set(0.5, 0.85)
     headSp.scale.set(this.tileSize / 64)
     headWrap.addChild(headSp)
@@ -58,6 +60,9 @@ export class TowerManager {
     const t = this.towers.find(t => t.uid === towerUid)
     if (!t) return false
     t.level++
+    const sprites = TowerSpriteMap[t.id as keyof typeof TowerSpriteMap]
+    const next = sprites[t.level - 1]
+    if (next) t.headSprite.texture = SvgAssets.texture(next)
     return true
   }
 

--- a/src/core/vfx/HitFlash.ts
+++ b/src/core/vfx/HitFlash.ts
@@ -1,0 +1,22 @@
+import { Graphics } from 'pixi.js'
+
+export class HitFlash extends Graphics {
+  private life = 0.15
+  constructor(x: number, y: number, size = 6, color = 0xffffff) {
+    super()
+    this.position.set(x, y)
+    this.lineStyle(2, color)
+    this.moveTo(-size, 0)
+    this.lineTo(size, 0)
+    this.moveTo(0, -size)
+    this.lineTo(0, size)
+  }
+  update(dt: number) {
+    this.life -= dt
+    this.alpha = this.life / 0.15
+    if (this.life <= 0) {
+      this.parent?.removeChild(this)
+      this.destroy()
+    }
+  }
+}

--- a/src/core/vfx/HitSpark.ts
+++ b/src/core/vfx/HitSpark.ts
@@ -1,0 +1,38 @@
+import { Container, Graphics } from 'pixi.js'
+
+interface Particle {
+  g: Graphics
+  vx: number
+  vy: number
+}
+
+export class HitSpark extends Container {
+  private life = 0.3
+  private parts: Particle[] = []
+  constructor(x: number, y: number, count = 5) {
+    super()
+    this.position.set(x, y)
+    for (let i = 0; i < count; i++) {
+      const g = new Graphics()
+      g.beginFill(0xffd700)
+      g.drawRect(-1, -1, 2, 2)
+      g.endFill()
+      const ang = Math.random() * Math.PI * 2
+      const spd = 60 + Math.random() * 80
+      this.parts.push({ g, vx: Math.cos(ang) * spd, vy: Math.sin(ang) * spd })
+      this.addChild(g)
+    }
+  }
+  update(dt: number) {
+    this.life -= dt
+    this.alpha = this.life / 0.3
+    for (const p of this.parts) {
+      p.g.x += p.vx * dt
+      p.g.y += p.vy * dt
+    }
+    if (this.life <= 0) {
+      this.parent?.removeChild(this)
+      this.destroy({ children: true })
+    }
+  }
+}

--- a/src/core/vfx/IceShatter.ts
+++ b/src/core/vfx/IceShatter.ts
@@ -1,0 +1,41 @@
+import { Container, Graphics } from 'pixi.js'
+
+interface Shard {
+  g: Graphics
+  vx: number
+  vy: number
+  vr: number
+}
+
+export class IceShatter extends Container {
+  private life = 0.6
+  private shards: Shard[] = []
+  constructor(x: number, y: number, count = 8, color = 0x93c5fd) {
+    super()
+    this.position.set(x, y)
+    for (let i = 0; i < count; i++) {
+      const g = new Graphics()
+      g.beginFill(color)
+      g.drawPolygon([0, 0, 2, -4, -2, -4])
+      g.endFill()
+      const ang = Math.random() * Math.PI * 2
+      const spd = 40 + Math.random() * 60
+      const vr = (Math.random() - 0.5) * 6
+      this.shards.push({ g, vx: Math.cos(ang) * spd, vy: Math.sin(ang) * spd, vr })
+      this.addChild(g)
+    }
+  }
+  update(dt: number) {
+    this.life -= dt
+    this.alpha = this.life / 0.6
+    for (const s of this.shards) {
+      s.g.x += s.vx * dt
+      s.g.y += s.vy * dt
+      s.g.rotation += s.vr * dt
+    }
+    if (this.life <= 0) {
+      this.parent?.removeChild(this)
+      this.destroy({ children: true })
+    }
+  }
+}

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -45,6 +45,7 @@ import level from '../core/data/levels/level01.json'
 import towersData from '../core/data/towers.json'
 import type { LevelConfig, TowerDef } from '../core/data/types'
 import { Assets } from '../core/engine/Assets'
+import { SvgAssets, TowerSpriteMap, TowerBasePad } from '../core/engine/SvgAssets'
 import { buildTileLayer, drawLane } from '../core/engine/Tilemap'
 import { Container } from 'pixi.js'
 import { Fx } from '../core/fx/FxSystem'
@@ -82,7 +83,10 @@ export default {
   methods: {
     async setup() {
       const canvas = this.$refs.canvas as HTMLCanvasElement
-      await Assets.load()
+      await Promise.all([
+        Assets.load(),
+        SvgAssets.preload([TowerBasePad, ...Object.values(TowerSpriteMap)])
+      ])
       game.init(canvas, this.level, {
         gold: v => (this.gold = v),
         life: v => (this.life = v),
@@ -103,6 +107,19 @@ export default {
       drawLane(game.renderer.laneLayer, this.level.paths[0].waypoints)
       canvas.addEventListener('pointermove', this.trackMouse)
       window.addEventListener('keydown', this.handleFxKeys)
+
+      const ts = this.level.tileSize
+      game.towers.placeTower('arrow', ts * 4, ts * 6)
+      game.towers.placeTower('cannon', ts * 6, ts * 6)
+      game.towers.placeTower('ice', ts * 8, ts * 6)
+      game.towers.placeTower('tesla', ts * 10, ts * 6)
+
+      const arrow = game.towers.towers.find(t => t.id === 'arrow')
+      if (arrow) {
+        setTimeout(() => {
+          game.towers.setTowerColor(arrow.uid, '#ef4444')
+        }, 1000)
+      }
     },
     startWave() { game.startNextWave() },
     togglePause() { game.togglePause() },

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -85,7 +85,7 @@ export default {
       const canvas = this.$refs.canvas as HTMLCanvasElement
       await Promise.all([
         Assets.load(),
-        SvgAssets.preload([TowerBasePad, ...Object.values(TowerSpriteMap)])
+        SvgAssets.preload([TowerBasePad, ...Object.values(TowerSpriteMap).flat()])
       ])
       game.init(canvas, this.level, {
         gold: v => (this.gold = v),
@@ -119,6 +119,11 @@ export default {
         setTimeout(() => {
           game.towers.setTowerColor(arrow.uid, '#ef4444')
         }, 1000)
+      }
+      const ice = game.towers.towers.find(t => t.id === 'ice')
+      if (ice) {
+        setTimeout(() => game.towers.upgradeTower(ice.uid), 1000)
+        setTimeout(() => game.towers.upgradeTower(ice.uid), 2000)
       }
     },
     startWave() { game.startNextWave() },


### PR DESCRIPTION
## Summary
- add tower SVG assets and loader with color replacement
- render towers from SVG textures with rotating heads
- preload assets in GameView and demo tower placement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ae34f9b24832794c6c7be9be1d432